### PR TITLE
update override json to use OCP 4.14

### DIFF
--- a/tests/pr_test.go
+++ b/tests/pr_test.go
@@ -159,9 +159,6 @@ func TestRunDAManage(t *testing.T) {
 		}
 	}()
 
-	// Temp workaround for cluster instability issues
-	fmt.Println("Sleeping for 30mins to allow cluster to stabilize..")
-	time.Sleep(1800 * time.Second)
 	output, err := options.RunTestConsistency()
 	assert.Nil(t, err, "This should not have errored")
 	assert.NotNil(t, output, "Expected some output")

--- a/tests/pr_test.go
+++ b/tests/pr_test.go
@@ -7,7 +7,6 @@ import (
 	"os"
 	"strings"
 	"testing"
-	"time"
 
 	"github.com/IBM/go-sdk-core/v5/core"
 	"github.com/gruntwork-io/terratest/modules/files"

--- a/tests/resources/override.json
+++ b/tests/resources/override.json
@@ -18,7 +18,7 @@
 				"private_endpoint": true
 			},
 			"kube_type": "openshift",
-			"kube_version": "4.12_openshift",
+			"kube_version": "4.14_openshift",
 			"machine_type": "bx2.16x64",
 			"manage_all_addons": false,
 			"name": "workload-cluster",


### PR DESCRIPTION
### Description

update override json to use OCP 4.14 to see if it improves cluster stability

### Release required?
<!--- Identify the type of release. For information about the changes in a semantic versioning release, see [Release versioning](https://terraform-ibm-modules.github.io/documentation/#/versioning). --->

- [ ] No release
- [ ] Patch release (`x.x.X`)
- [ ] Minor release (`x.X.x`)
- [ ] Major release (`X.x.x`)

##### Release notes content

<!--- If a release is required, replace this text with information that users need to know about the release. Write the release notes to help users understand the changes, and include information about how to update from the previous version.

Your notes help the merger write the commit message for the PR that is published in the release notes for the module. --->

### Run the pipeline

If the CI pipeline doesn't run when you create the PR, the PR requires a user with GitHub collaborators access to run the pipeline.

Run the CI pipeline when the PR is ready for review and you expect tests to pass. Add a comment to the PR with the following text:

```
/run pipeline
```

### Checklist for reviewers

- [ ] If relevant, a test for the change is included or updated with this PR.
- [ ] If relevant, documentation for the change is included or updated with this PR.

### For mergers

- Use a conventional commit message to set the release level. Follow the [guidelines](https://terraform-ibm-modules.github.io/documentation/#/merging.md).
- Include information that users need to know about the PR in the commit message. The commit message becomes part of the GitHub release notes.
- Use the **Squash and merge** option.
