### PR TITLE
fix: triaging ephemeral storage issue..

### DIFF
--- a/override-json-file/override.json
+++ b/override-json-file/override.json
@@ -19,7 +19,7 @@
 			},
 			"kube_type": "openshift",
 			"kube_version": "4.14_openshift",
-			"machine_type": "ox2.16x128",
+			"machine_type": "bx2-16x64",
 			"manage_all_addons": false,
 			"name": "workload-cluster",
 			"resource_group": "workload-rg",

--- a/override-json-file/override.json
+++ b/override-json-file/override.json
@@ -19,11 +19,11 @@
 			},
 			"kube_type": "openshift",
 			"kube_version": "4.14_openshift",
-			"machine_type": "bx2-16x64",
+			"machine_type": "ox2.16x128",
 			"manage_all_addons": false,
 			"name": "workload-cluster",
 			"resource_group": "workload-rg",
-			"secondary_storage": null,
+			"secondary_storage": "300gb.5iops-tier",
 			"subnet_names": [
 				"vsi-zone-1",
 				"vsi-zone-2",

--- a/override-json-file/override.json
+++ b/override-json-file/override.json
@@ -19,11 +19,11 @@
 			},
 			"kube_type": "openshift",
 			"kube_version": "4.14_openshift",
-			"machine_type": "ox2.16x128",
+			"machine_type": "bx2.16x64",
 			"manage_all_addons": false,
 			"name": "workload-cluster",
 			"resource_group": "workload-rg",
-			"secondary_storage": "300gb.5iops-tier",
+			"secondary_storage": "300gb.10iops-tier",
 			"subnet_names": [
 				"vsi-zone-1",
 				"vsi-zone-2",

--- a/override-json-file/override.json
+++ b/override-json-file/override.json
@@ -19,7 +19,7 @@
 			},
 			"kube_type": "openshift",
 			"kube_version": "4.14_openshift",
-			"machine_type": "bx2.16x64",
+			"machine_type": "ox2.16x128",
 			"manage_all_addons": false,
 			"name": "workload-cluster",
 			"resource_group": "workload-rg",


### PR DESCRIPTION
### Description

Update override json to use "secondary_storage": "300gb.10iops-tier" (secondary storage of 300 GB with 10 input/output per second) to solve ephemeral storage issue seen during Manage build.

### Release required?
<!--- Identify the type of release. For information about the changes in a semantic versioning release, see [Release versioning](https://terraform-ibm-modules.github.io/documentation/#/versioning). --->

- [ ] No release
- [ ] Patch release (`x.x.X`)
- [ ] Minor release (`x.X.x`)
- [ ] Major release (`X.x.x`)

##### Release notes content

<!--- If a release is required, replace this text with information that users need to know about the release. Write the release notes to help users understand the changes, and include information about how to update from the previous version.

Your notes help the merger write the commit message for the PR that is published in the release notes for the module. --->

### Run the pipeline

If the CI pipeline doesn't run when you create the PR, the PR requires a user with GitHub collaborators access to run the pipeline.

Run the CI pipeline when the PR is ready for review and you expect tests to pass. Add a comment to the PR with the following text:

```
/run pipeline
```

### Checklist for reviewers

- [ ] If relevant, a test for the change is included or updated with this PR.
- [ ] If relevant, documentation for the change is included or updated with this PR.

### For mergers

- Use a conventional commit message to set the release level. Follow the [guidelines](https://terraform-ibm-modules.github.io/documentation/#/merging.md).
- Include information that users need to know about the PR in the commit message. The commit message becomes part of the GitHub release notes.
- Use the **Squash and merge** option.
